### PR TITLE
[feat] 장소 상세정보 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/main/resources/application.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/gongmo/tourgather/controller/FooController.java
+++ b/src/main/java/com/gongmo/tourgather/controller/FooController.java
@@ -10,7 +10,7 @@ import com.gongmo.tourgather.controller.dto.response.FooResponse;
 import com.gongmo.tourgather.controller.dto.response.ApplicationResponse;
 import com.gongmo.tourgather.service.FooService;
 
-@RequestMapping("/api/foo")
+@RequestMapping("/api/v1/foo")
 @RestController
 @RequiredArgsConstructor
 public class FooController {

--- a/src/main/java/com/gongmo/tourgather/controller/PlaceController.java
+++ b/src/main/java/com/gongmo/tourgather/controller/PlaceController.java
@@ -1,0 +1,28 @@
+package com.gongmo.tourgather.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.gongmo.tourgather.controller.dto.response.ApplicationResponse;
+import com.gongmo.tourgather.controller.dto.response.PlaceResponse;
+import com.gongmo.tourgather.service.PlaceService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/v1/places")
+@RestController
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping("/{placeId}")
+    public ResponseEntity<ApplicationResponse<PlaceResponse>> findById(@PathVariable Long placeId, @RequestParam String lang) {
+        PlaceResponse response = placeService.findById(placeId, lang);
+        return ResponseEntity.ok(ApplicationResponse.success(response));
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/FooResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/FooResponse.java
@@ -2,15 +2,7 @@ package com.gongmo.tourgather.controller.dto.response;
 
 import com.gongmo.tourgather.repository.entity.Foo;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class FooResponse {
-
-    private final Long id;
-    private final String name;
+public record FooResponse(Long id, String name) {
 
     public static FooResponse from(Foo foo) {
         return new FooResponse(foo.getId(), foo.getName());

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/HashTagResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/HashTagResponse.java
@@ -1,0 +1,10 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import com.gongmo.tourgather.repository.entity.HashTag;
+
+public record HashTagResponse(long id, String name, String description) {
+
+    public static HashTagResponse from(HashTag hashTag) {
+        return new HashTagResponse(hashTag.getId(), hashTag.getName(), hashTag.getDescription());
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceDescriptionResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceDescriptionResponse.java
@@ -1,0 +1,10 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import com.gongmo.tourgather.repository.entity.PlaceTranslation;
+
+public record PlaceDescriptionResponse(String place, String idol) {
+
+    public static PlaceDescriptionResponse from(PlaceTranslation translation) {
+        return new PlaceDescriptionResponse(translation.getDescription(), translation.getIdolDescription());
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceImageResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceImageResponse.java
@@ -1,0 +1,16 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import java.util.List;
+
+import com.gongmo.tourgather.domain.ImagePlaceType;
+import com.gongmo.tourgather.repository.entity.Place;
+
+public record PlaceImageResponse(List<String> place, List<String> idol) {
+
+    public static PlaceImageResponse from(Place place) {
+        return new PlaceImageResponse(
+            place.extractImageTo(ImagePlaceType.BASIC),
+            place.extractImageTo(ImagePlaceType.IDOL)
+        );
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceLinkResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceLinkResponse.java
@@ -1,0 +1,10 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import com.gongmo.tourgather.repository.entity.Place;
+
+public record PlaceLinkResponse(String place, String idol) {
+
+    public static PlaceLinkResponse from(Place place) {
+        return new PlaceLinkResponse(place.getLink(), place.getIdolLink());
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/PlaceResponse.java
@@ -1,0 +1,31 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import java.util.List;
+
+import com.gongmo.tourgather.repository.entity.Place;
+import com.gongmo.tourgather.repository.entity.PlaceHashTag;
+import com.gongmo.tourgather.repository.entity.PlaceTranslation;
+import com.gongmo.tourgather.repository.entity.SingerPlace;
+
+public record PlaceResponse(
+    long id, String name, String address, String openTime,
+    PlaceLinkResponse link, List<HashTagResponse> hashtag, List<SingerResponse> singer,
+    PlaceDescriptionResponse description, PlaceImageResponse image) {
+
+    public static PlaceResponse from(Place place, PlaceTranslation translation) {
+        return new PlaceResponse(
+            place.getId(), translation.getName(), place.getAddress().getFullAddress(), translation.getOpenTime(),
+            PlaceLinkResponse.from(place),
+            place.getHashTags().stream()
+                .map(PlaceHashTag::getHashTag)
+                .map(HashTagResponse::from)
+                .toList(),
+            place.getSingers().stream()
+                .map(SingerPlace::getSinger)
+                .map(SingerResponse::from)
+                .toList(),
+            PlaceDescriptionResponse.from(translation),
+            PlaceImageResponse.from(place)
+        );
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/controller/dto/response/SingerResponse.java
+++ b/src/main/java/com/gongmo/tourgather/controller/dto/response/SingerResponse.java
@@ -1,0 +1,10 @@
+package com.gongmo.tourgather.controller.dto.response;
+
+import com.gongmo.tourgather.repository.entity.Singer;
+
+public record SingerResponse(long id, String name, String group) {
+
+    public static SingerResponse from(Singer singer) {
+        return new SingerResponse(singer.getId(), singer.getName(), singer.getGroup());
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/domain/ImagePlaceType.java
+++ b/src/main/java/com/gongmo/tourgather/domain/ImagePlaceType.java
@@ -1,0 +1,14 @@
+package com.gongmo.tourgather.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ImagePlaceType {
+
+    BASIC("basic", "장소 관련 이미지"),
+    IDOL("idol", "아이돌 관련 이미지"),
+    ;
+
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/com/gongmo/tourgather/domain/LanguageErrorCode.java
+++ b/src/main/java/com/gongmo/tourgather/domain/LanguageErrorCode.java
@@ -1,0 +1,33 @@
+package com.gongmo.tourgather.domain;
+
+import org.springframework.http.HttpStatus;
+
+import com.gongmo.tourgather.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum LanguageErrorCode implements ErrorCode {
+
+    INVALID_LANGUAGE("L0001", HttpStatus.BAD_REQUEST, "존재하지 않는 언어 코드입니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getStatusCode() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/domain/PlaceErrorCode.java
+++ b/src/main/java/com/gongmo/tourgather/domain/PlaceErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum PlaceErrorCode implements ErrorCode {
 
     NOT_EXIST_PLACE("P0001", HttpStatus.BAD_REQUEST, "존재하지 않는 장소입니다."),
-    NOT_EXIST_PLACE_TRANSLATION("P0001", HttpStatus.BAD_REQUEST, "장소의 다국어 정보가 존재하지 않습니다."),
+    NOT_EXIST_PLACE_TRANSLATION("P0002", HttpStatus.BAD_REQUEST, "장소의 다국어 정보가 존재하지 않습니다."),
+    NOT_EXIST_PLACE_ADDRESS("P0003", HttpStatus.BAD_REQUEST, "장소의 주소 정보가 존재하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/gongmo/tourgather/domain/PlaceErrorCode.java
+++ b/src/main/java/com/gongmo/tourgather/domain/PlaceErrorCode.java
@@ -1,0 +1,34 @@
+package com.gongmo.tourgather.domain;
+
+import org.springframework.http.HttpStatus;
+
+import com.gongmo.tourgather.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PlaceErrorCode implements ErrorCode {
+
+    NOT_EXIST_PLACE("P0001", HttpStatus.BAD_REQUEST, "존재하지 않는 장소입니다."),
+    NOT_EXIST_PLACE_TRANSLATION("P0001", HttpStatus.BAD_REQUEST, "장소의 다국어 정보가 존재하지 않습니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getStatusCode() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/repository/LanguageRepository.java
+++ b/src/main/java/com/gongmo/tourgather/repository/LanguageRepository.java
@@ -1,0 +1,14 @@
+package com.gongmo.tourgather.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.gongmo.tourgather.repository.entity.Language;
+
+@Repository
+public interface LanguageRepository extends JpaRepository<Language, Long> {
+
+    Optional<Language> findByCode(String code);
+}

--- a/src/main/java/com/gongmo/tourgather/repository/PlaceRepository.java
+++ b/src/main/java/com/gongmo/tourgather/repository/PlaceRepository.java
@@ -1,0 +1,23 @@
+package com.gongmo.tourgather.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.gongmo.tourgather.repository.entity.Language;
+import com.gongmo.tourgather.repository.entity.Place;
+
+@Repository
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    @Query(
+        "select p "
+            + "from Place p "
+            + "left join fetch p.placeTranslation t "
+            + "where p.id = :id "
+            + "and t.language = :language "
+    )
+    Optional<Place> findByIdWithLang(Long placeId, Language language);
+}

--- a/src/main/java/com/gongmo/tourgather/repository/PlaceRepository.java
+++ b/src/main/java/com/gongmo/tourgather/repository/PlaceRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.gongmo.tourgather.repository.entity.Language;
@@ -15,9 +16,13 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query(
         "select p "
             + "from Place p "
+            + "left join fetch p.address a "
             + "left join fetch p.placeTranslation t "
+            + "left join fetch p.hashTags h "
+            + "left join fetch p.singers s "
+            + "left join fetch p.images i "
             + "where p.id = :id "
             + "and t.language = :language "
     )
-    Optional<Place> findByIdWithLang(Long placeId, Language language);
+    Optional<Place> findByIdAndLang(@Param("id") Long id, @Param("language") Language language);
 }

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
@@ -1,0 +1,31 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "language_id")
+    private Language language;
+
+    private String sido;
+    private String sigungu;
+    private String road;
+    private String detail;
+    private String zipcode;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
@@ -1,5 +1,6 @@
 package com.gongmo.tourgather.repository.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -7,10 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Address {
@@ -19,7 +24,7 @@ public class Address {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "language_id")
     private Language language;
 

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Address.java
@@ -28,4 +28,8 @@ public class Address {
     private String road;
     private String detail;
     private String zipcode;
+
+    public String getFullAddress() {
+        return String.format("%s %s %s %s", sido, sigungu, road, detail);
+    }
 }

--- a/src/main/java/com/gongmo/tourgather/repository/entity/HashTag.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/HashTag.java
@@ -1,0 +1,25 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class HashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(length = 3000)
+    private String description;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/ImagePlace.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/ImagePlace.java
@@ -1,0 +1,27 @@
+package com.gongmo.tourgather.repository.entity;
+
+import com.gongmo.tourgather.domain.ImagePlaceType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ImagePlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated
+    private ImagePlaceType imageType;
+
+    private String image;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Language.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Language.java
@@ -17,4 +17,8 @@ public class Language {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String code;
+
+    public Language(String code) {
+        this.code = code;
+    }
 }

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Language.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Language.java
@@ -1,0 +1,20 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Language {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String code;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
@@ -3,10 +3,12 @@ package com.gongmo.tourgather.repository.entity;
 import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_TRANSLATION;
 
 import java.util.List;
+import java.util.Set;
 
 import com.gongmo.tourgather.domain.ImagePlaceType;
 import com.gongmo.tourgather.exception.ApplicationException;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,10 +18,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Place {
@@ -28,25 +34,25 @@ public class Place {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "address_id")
     private Address address;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "place_id")
-    private List<PlaceTranslation> placeTranslation;
+    private Set<PlaceTranslation> placeTranslation;
 
     @OneToMany
     @JoinColumn(name = "place_id")
-    private List<PlaceHashTag> hashTags;
+    private Set<PlaceHashTag> hashTags;
 
     @OneToMany
     @JoinColumn(name = "place_id")
-    private List<SingerPlace> singers;
+    private Set<SingerPlace> singers;
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
-    private List<ImagePlace> images;
+    private Set<ImagePlace> images;
 
     private String link;
     private String idolLink;
@@ -55,10 +61,9 @@ public class Place {
     private double longitude;
 
     public PlaceTranslation getTranslation() {
-        if (placeTranslation == null || placeTranslation.isEmpty()) {
-            throw new ApplicationException(NOT_EXIST_PLACE_TRANSLATION);
-        }
-        return placeTranslation.get(0);
+        return placeTranslation.stream()
+            .findFirst()
+            .orElseThrow(() -> new ApplicationException(NOT_EXIST_PLACE_TRANSLATION));
     }
 
     public List<String> extractImageTo(ImagePlaceType type) {

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
@@ -1,6 +1,11 @@
 package com.gongmo.tourgather.repository.entity;
 
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_TRANSLATION;
+
 import java.util.List;
+
+import com.gongmo.tourgather.domain.ImagePlaceType;
+import com.gongmo.tourgather.exception.ApplicationException;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -48,4 +53,18 @@ public class Place {
 
     private double latitude;
     private double longitude;
+
+    public PlaceTranslation getTranslation() {
+        if (placeTranslation == null || placeTranslation.isEmpty()) {
+            throw new ApplicationException(NOT_EXIST_PLACE_TRANSLATION);
+        }
+        return placeTranslation.get(0);
+    }
+
+    public List<String> extractImageTo(ImagePlaceType type) {
+        return images.stream()
+            .filter(image -> image.getImageType().equals(type))
+            .map(ImagePlace::getImage)
+            .toList();
+    }
 }

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
@@ -1,5 +1,6 @@
 package com.gongmo.tourgather.repository.entity;
 
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_ADDRESS;
 import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_TRANSLATION;
 
 import java.util.List;
@@ -15,7 +16,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,9 +34,9 @@ public class Place {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "address_id")
-    private Address address;
+    private Set<Address> address;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "place_id")
@@ -59,6 +59,12 @@ public class Place {
 
     private double latitude;
     private double longitude;
+
+    public Address getAddress() {
+        return address.stream()
+            .findFirst()
+            .orElseThrow(() -> new ApplicationException(NOT_EXIST_PLACE_ADDRESS));
+    }
 
     public PlaceTranslation getTranslation() {
         return placeTranslation.stream()

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Place.java
@@ -1,0 +1,51 @@
+package com.gongmo.tourgather.repository.entity;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private List<PlaceTranslation> placeTranslation;
+
+    @OneToMany
+    @JoinColumn(name = "place_id")
+    private List<PlaceHashTag> hashTags;
+
+    @OneToMany
+    @JoinColumn(name = "place_id")
+    private List<SingerPlace> singers;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private List<ImagePlace> images;
+
+    private String link;
+    private String idolLink;
+
+    private double latitude;
+    private double longitude;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/PlaceHashTag.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/PlaceHashTag.java
@@ -1,0 +1,29 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PlaceHashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id")
+    private HashTag hashTag;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/PlaceTranslation.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/PlaceTranslation.java
@@ -1,0 +1,30 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PlaceTranslation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "language_id")
+    private Language language;
+
+    private String name;
+    private String openTime;
+    private String description;
+    private String idolDescription;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/PlaceTranslation.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/PlaceTranslation.java
@@ -1,5 +1,6 @@
 package com.gongmo.tourgather.repository.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -7,10 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlaceTranslation {
@@ -19,7 +24,7 @@ public class PlaceTranslation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "language_id")
     private Language language;
 

--- a/src/main/java/com/gongmo/tourgather/repository/entity/Singer.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/Singer.java
@@ -1,0 +1,22 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Singer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String group;
+}

--- a/src/main/java/com/gongmo/tourgather/repository/entity/SingerPlace.java
+++ b/src/main/java/com/gongmo/tourgather/repository/entity/SingerPlace.java
@@ -1,0 +1,29 @@
+package com.gongmo.tourgather.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SingerPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "singer_id")
+    private Singer singer;
+
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+}

--- a/src/main/java/com/gongmo/tourgather/service/PlaceService.java
+++ b/src/main/java/com/gongmo/tourgather/service/PlaceService.java
@@ -1,0 +1,42 @@
+package com.gongmo.tourgather.service;
+
+import static com.gongmo.tourgather.domain.LanguageErrorCode.INVALID_LANGUAGE;
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.gongmo.tourgather.controller.dto.response.PlaceResponse;
+import com.gongmo.tourgather.exception.ApplicationException;
+import com.gongmo.tourgather.repository.LanguageRepository;
+import com.gongmo.tourgather.repository.PlaceRepository;
+import com.gongmo.tourgather.repository.entity.Language;
+import com.gongmo.tourgather.repository.entity.Place;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+    private final LanguageRepository languageRepository;
+
+    @Transactional(readOnly = true)
+    public PlaceResponse findById(Long placeId, String lang) {
+        Language language = findLanguage(lang);
+        Place savedPlace = findPlaceById(placeId, language);
+        return PlaceResponse.from(savedPlace, savedPlace.getTranslation());
+    }
+
+    private Language findLanguage(String lang) {
+        return languageRepository.findByCode(lang)
+            .orElseThrow(() -> new ApplicationException(INVALID_LANGUAGE));
+    }
+
+    private Place findPlaceById(Long placeId, Language language) {
+        return placeRepository.findByIdWithLang(placeId, language)
+            .orElseThrow(() -> new ApplicationException(NOT_EXIST_PLACE));
+    }
+}

--- a/src/main/java/com/gongmo/tourgather/service/PlaceService.java
+++ b/src/main/java/com/gongmo/tourgather/service/PlaceService.java
@@ -24,9 +24,9 @@ public class PlaceService {
     private final LanguageRepository languageRepository;
 
     @Transactional(readOnly = true)
-    public PlaceResponse findById(Long placeId, String lang) {
+    public PlaceResponse findById(Long id, String lang) {
         Language language = findLanguage(lang);
-        Place savedPlace = findPlaceById(placeId, language);
+        Place savedPlace = findPlaceById(id, language);
         return PlaceResponse.from(savedPlace, savedPlace.getTranslation());
     }
 
@@ -35,8 +35,8 @@ public class PlaceService {
             .orElseThrow(() -> new ApplicationException(INVALID_LANGUAGE));
     }
 
-    private Place findPlaceById(Long placeId, Language language) {
-        return placeRepository.findByIdWithLang(placeId, language)
+    private Place findPlaceById(Long id, Language language) {
+        return placeRepository.findByIdAndLang(id, language)
             .orElseThrow(() -> new ApplicationException(NOT_EXIST_PLACE));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=tourgather

--- a/src/test/java/com/gongmo/tourgather/fixture/AddressFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/AddressFixture.java
@@ -1,0 +1,33 @@
+package com.gongmo.tourgather.fixture;
+
+import static com.gongmo.tourgather.fixture.LanguageFixture.KOR;
+
+import com.gongmo.tourgather.repository.entity.Address;
+import com.gongmo.tourgather.repository.entity.Language;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AddressFixture {
+
+    MAHOGANY_CAFE_ADDRESS_KOR(KOR.toDomain(), "서울특별시", "중구", "청계천로 24", "1층", "04521"),
+    ;
+
+    private final Language language;
+    private final String sido;
+    private final String sigungu;
+    private final String road;
+    private final String detail;
+    private final String zipcode;
+
+    public Address toDomain() {
+        return Address.builder()
+            .language(language)
+            .sido(sido)
+            .sigungu(sigungu)
+            .road(road)
+            .detail(detail)
+            .zipcode(zipcode)
+            .build();
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/fixture/LanguageFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/LanguageFixture.java
@@ -1,0 +1,23 @@
+package com.gongmo.tourgather.fixture;
+
+import com.gongmo.tourgather.repository.entity.Language;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum LanguageFixture {
+
+    KOR("kor"),
+    ;
+
+    private final String code;
+
+    private Language language;
+
+    public Language toDomain() {
+        if (language == null) {
+            language = new Language(code);
+        }
+        return language;
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
@@ -39,6 +39,17 @@ public enum PlaceFixture {
     private final double longitude;
 
     public Place toDomain() {
+        return createBuilder()
+            .build();
+    }
+
+    public Place toDomainWithId(Long id) {
+        return createBuilder()
+            .id(id)
+            .build();
+    }
+
+    private Place.PlaceBuilder createBuilder() {
         return Place.builder()
             .address(address)
             .placeTranslation(placeTranslation)
@@ -48,7 +59,6 @@ public enum PlaceFixture {
             .link(link)
             .idolLink(idolLink)
             .latitude(latitude)
-            .longitude(longitude)
-            .build();
+            .longitude(longitude);
     }
 }

--- a/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
@@ -1,0 +1,54 @@
+package com.gongmo.tourgather.fixture;
+
+import static com.gongmo.tourgather.fixture.AddressFixture.MAHOGANY_CAFE_ADDRESS_KOR;
+import static com.gongmo.tourgather.fixture.PlaceTranslationFixture.MAHOGANY_CAFE_TRANSLATION_KOR;
+
+import java.util.Set;
+
+import com.gongmo.tourgather.repository.entity.Address;
+import com.gongmo.tourgather.repository.entity.ImagePlace;
+import com.gongmo.tourgather.repository.entity.Place;
+import com.gongmo.tourgather.repository.entity.PlaceHashTag;
+import com.gongmo.tourgather.repository.entity.PlaceTranslation;
+import com.gongmo.tourgather.repository.entity.SingerPlace;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PlaceFixture {
+
+    MAHOGANY_CAFE_PLACE_KOR(
+        MAHOGANY_CAFE_ADDRESS_KOR.toDomain(),
+        Set.of(MAHOGANY_CAFE_TRANSLATION_KOR.toDomain()),
+        Set.of(),
+        Set.of(),
+        Set.of(),
+        "https://map.naver.com/p/entry/place/1371876716?c=15.00,0,0,0,dh&placePath=/home",
+        "",
+        37.568654, 126.9800339),
+    ;
+
+    private final Address address;
+    private final Set<PlaceTranslation> placeTranslation;
+    private final Set<PlaceHashTag> hashTags;
+    private final Set<SingerPlace> singers;
+    private final Set<ImagePlace> images;
+    private final String link;
+    private final String idolLink;
+    private final double latitude;
+    private final double longitude;
+
+    public Place toDomain() {
+        return Place.builder()
+            .address(address)
+            .placeTranslation(placeTranslation)
+            .hashTags(hashTags)
+            .singers(singers)
+            .images(images)
+            .link(link)
+            .idolLink(idolLink)
+            .latitude(latitude)
+            .longitude(longitude)
+            .build();
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
@@ -3,6 +3,7 @@ package com.gongmo.tourgather.fixture;
 import static com.gongmo.tourgather.fixture.AddressFixture.MAHOGANY_CAFE_ADDRESS_KOR;
 import static com.gongmo.tourgather.fixture.PlaceTranslationFixture.MAHOGANY_CAFE_TRANSLATION_KOR;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import com.gongmo.tourgather.repository.entity.Address;
@@ -12,8 +13,10 @@ import com.gongmo.tourgather.repository.entity.PlaceHashTag;
 import com.gongmo.tourgather.repository.entity.PlaceTranslation;
 import com.gongmo.tourgather.repository.entity.SingerPlace;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum PlaceFixture {
 
@@ -46,6 +49,18 @@ public enum PlaceFixture {
     public Place toDomainWithId(Long id) {
         return createBuilder()
             .id(id)
+            .build();
+    }
+
+    public Place toDomainWithoutAddress() {
+        return createBuilder()
+            .address(new HashSet<>())
+            .build();
+    }
+
+    public Place toDomainWithoutTranslation() {
+        return createBuilder()
+            .placeTranslation(new HashSet<>())
             .build();
     }
 

--- a/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/PlaceFixture.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 public enum PlaceFixture {
 
     MAHOGANY_CAFE_PLACE_KOR(
-        MAHOGANY_CAFE_ADDRESS_KOR.toDomain(),
+        Set.of(MAHOGANY_CAFE_ADDRESS_KOR.toDomain()),
         Set.of(MAHOGANY_CAFE_TRANSLATION_KOR.toDomain()),
         Set.of(),
         Set.of(),
@@ -28,7 +28,7 @@ public enum PlaceFixture {
         37.568654, 126.9800339),
     ;
 
-    private final Address address;
+    private final Set<Address> address;
     private final Set<PlaceTranslation> placeTranslation;
     private final Set<PlaceHashTag> hashTags;
     private final Set<SingerPlace> singers;

--- a/src/test/java/com/gongmo/tourgather/fixture/PlaceTranslationFixture.java
+++ b/src/test/java/com/gongmo/tourgather/fixture/PlaceTranslationFixture.java
@@ -1,0 +1,36 @@
+package com.gongmo.tourgather.fixture;
+
+import static com.gongmo.tourgather.fixture.LanguageFixture.KOR;
+
+import com.gongmo.tourgather.repository.entity.Language;
+import com.gongmo.tourgather.repository.entity.PlaceTranslation;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PlaceTranslationFixture {
+
+    MAHOGANY_CAFE_TRANSLATION_KOR(
+        KOR.toDomain(),
+        "마호가니 광화문 케이스퀘어시티점",
+        "21:30 에 라스트 오더",
+        "공모걸즈 첫 모임 장소 :)",
+        ""),
+    ;
+
+    private final Language language;
+    private final String name;
+    private final String openTime;
+    private final String description;
+    private final String idolDescription;
+
+    public PlaceTranslation toDomain() {
+        return PlaceTranslation.builder()
+            .language(language)
+            .name(name)
+            .openTime(openTime)
+            .description(description)
+            .idolDescription(idolDescription)
+            .build();
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/respository/LanguageRepositoryTest.java
+++ b/src/test/java/com/gongmo/tourgather/respository/LanguageRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.gongmo.tourgather.respository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.gongmo.tourgather.repository.LanguageRepository;
+import com.gongmo.tourgather.repository.entity.Language;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public class LanguageRepositoryTest {
+
+    @Autowired
+    private LanguageRepository languageRepository;
+
+    @DisplayName("언어 코드를 이용하여 Language 를 조회한다")
+    @Nested
+    class findByCode {
+
+        @DisplayName("Language Entity 를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            String lang = "kor";
+            languageRepository.save(new Language(lang));
+
+            // when
+            Optional<Language> language = languageRepository.findByCode(lang);
+
+            // then
+            assertThat(language).isPresent();
+        }
+
+        @DisplayName("존재하지 않는 언어 코드로 조회하는 경우 빈 값이 조회된다")
+        @Test
+        void notExist() {
+            // given
+            String notExistLang = "notExist";
+
+            // when
+            Optional<Language> language = languageRepository.findByCode(notExistLang);
+
+            // then
+            assertThat(language).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/respository/PlaceRepositoryTest.java
+++ b/src/test/java/com/gongmo/tourgather/respository/PlaceRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.gongmo.tourgather.respository;
+
+import static com.gongmo.tourgather.fixture.PlaceFixture.MAHOGANY_CAFE_PLACE_KOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.gongmo.tourgather.repository.LanguageRepository;
+import com.gongmo.tourgather.repository.PlaceRepository;
+import com.gongmo.tourgather.repository.entity.Language;
+import com.gongmo.tourgather.repository.entity.Place;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public class PlaceRepositoryTest {
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private LanguageRepository languageRepository;
+
+    @DisplayName("원하는 언어 코드의 장소 정보를 조회한다")
+    @Nested
+    class findByIdAndLang {
+
+        @DisplayName("Place Entity 를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            Place savedPlace = placeRepository.save(MAHOGANY_CAFE_PLACE_KOR.toDomain());
+
+            // when
+            Optional<Place> place = placeRepository.findByIdAndLang(savedPlace.getId(), savedPlace.getAddress().getLanguage());
+
+            // then
+            assertThat(place).isPresent();
+        }
+
+        @DisplayName("장소 아이디에 해당하는 정보가 없을 경우 빈 값이 조회된다")
+        @Test
+        void notExist() {
+            // given
+            long notExistId = 0L;
+            Language savedLanguage = languageRepository.save(new Language("kor"));
+
+            // when
+            Optional<Place> place = placeRepository.findByIdAndLang(notExistId, savedLanguage);
+
+            // then
+            assertThat(place).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/respository/entity/AddressTest.java
+++ b/src/test/java/com/gongmo/tourgather/respository/entity/AddressTest.java
@@ -1,0 +1,38 @@
+package com.gongmo.tourgather.respository.entity;
+
+import static com.gongmo.tourgather.fixture.AddressFixture.MAHOGANY_CAFE_ADDRESS_KOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.gongmo.tourgather.repository.entity.Address;
+
+public class AddressTest {
+
+    @DisplayName("전체 주소 정보를 조회한다")
+    @Nested
+    class getFullAddress {
+
+        @DisplayName("전체 주소 정보를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            Address address = MAHOGANY_CAFE_ADDRESS_KOR.toDomain();
+
+            // when
+            String fullAddress = address.getFullAddress();
+
+            // then
+            assertAll(
+                () -> assertThat(fullAddress).contains(
+                    address.getSido(),
+                    address.getSigungu(),
+                    address.getRoad(),
+                    address.getDetail()),
+                () -> assertThat(fullAddress).doesNotContain(address.getZipcode()));
+        }
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/respository/entity/PlaceTest.java
+++ b/src/test/java/com/gongmo/tourgather/respository/entity/PlaceTest.java
@@ -1,0 +1,96 @@
+package com.gongmo.tourgather.respository.entity;
+
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_ADDRESS;
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE_TRANSLATION;
+import static com.gongmo.tourgather.fixture.PlaceFixture.MAHOGANY_CAFE_PLACE_KOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.gongmo.tourgather.domain.ImagePlaceType;
+import com.gongmo.tourgather.fixture.PlaceFixture;
+import com.gongmo.tourgather.repository.entity.Address;
+import com.gongmo.tourgather.repository.entity.Place;
+import com.gongmo.tourgather.repository.entity.PlaceTranslation;
+
+public class PlaceTest {
+
+    @DisplayName("주소 정보를 조회한다")
+    @Nested
+    class getAddress {
+
+        @DisplayName("주소 정보를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            PlaceFixture placeFixture = MAHOGANY_CAFE_PLACE_KOR;
+
+            // when
+            Address address = placeFixture.toDomain().getAddress();
+
+            // then
+            assertThat(placeFixture.getAddress()).contains(address);
+        }
+
+        @DisplayName("주소 정보가 없을 경우 예외가 발생한다")
+        @Test
+        void empty() {
+            // given
+            Place place = MAHOGANY_CAFE_PLACE_KOR.toDomainWithoutAddress();
+
+            // when & then
+            assertThatThrownBy(place::getAddress)
+                .hasMessage(NOT_EXIST_PLACE_ADDRESS.getMessage());
+        }
+    }
+
+    @DisplayName("다국어 정보를 조회한다")
+    @Nested
+    class getTranslation {
+
+        @DisplayName("다국어 정보를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            PlaceFixture placeFixture = MAHOGANY_CAFE_PLACE_KOR;
+
+            // when
+            PlaceTranslation translation = placeFixture.toDomain().getTranslation();
+
+            // then
+            assertThat(placeFixture.getPlaceTranslation()).contains(translation);
+        }
+
+        @DisplayName("다국어 정보가 없을 경우 예외가 발생한다")
+        @Test
+        void empty() {
+            // given
+            Place place = MAHOGANY_CAFE_PLACE_KOR.toDomainWithoutTranslation();
+
+            // when & then
+            assertThatThrownBy(place::getTranslation)
+                .hasMessage(NOT_EXIST_PLACE_TRANSLATION.getMessage());
+        }
+    }
+
+    @DisplayName("특정 타입에 맞는 이미지만 추출한다")
+    @Nested
+    class extractImageTo {
+
+        @DisplayName("특정 타입에 맞는 이미지를 성공적으로 추출한다")
+        @Test
+        void success() {
+            // given
+            ImagePlaceType type = ImagePlaceType.IDOL;
+            Place place = MAHOGANY_CAFE_PLACE_KOR.toDomain();
+
+            // when & then
+            assertThatCode(() -> place.extractImageTo(type))
+                .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/gongmo/tourgather/service/PlaceServiceTest.java
+++ b/src/test/java/com/gongmo/tourgather/service/PlaceServiceTest.java
@@ -1,0 +1,90 @@
+package com.gongmo.tourgather.service;
+
+import static com.gongmo.tourgather.domain.LanguageErrorCode.INVALID_LANGUAGE;
+import static com.gongmo.tourgather.domain.PlaceErrorCode.NOT_EXIST_PLACE;
+import static com.gongmo.tourgather.fixture.PlaceFixture.MAHOGANY_CAFE_PLACE_KOR;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.gongmo.tourgather.controller.dto.response.PlaceResponse;
+import com.gongmo.tourgather.repository.LanguageRepository;
+import com.gongmo.tourgather.repository.PlaceRepository;
+import com.gongmo.tourgather.repository.entity.Language;
+import com.gongmo.tourgather.repository.entity.Place;
+
+@ExtendWith(MockitoExtension.class)
+public class PlaceServiceTest {
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private LanguageRepository languageRepository;
+
+    @InjectMocks
+    private PlaceService placeService;
+
+    @DisplayName("Place 를 조회한다")
+    @Nested
+    class findById {
+
+        @DisplayName("Place 를 성공적으로 조회한다")
+        @Test
+        void success() {
+            // given
+            long id = 1L;
+            String lang = "kor";
+
+            // mock
+            Language language = new Language(lang);
+            Place place = MAHOGANY_CAFE_PLACE_KOR.toDomainWithId(id);
+            when(languageRepository.findByCode(lang)).thenReturn(Optional.of(language));
+            when(placeRepository.findByIdAndLang(id, language)).thenReturn(Optional.of(place));
+
+            // when
+            PlaceResponse response = placeService.findById(id, lang);
+
+            // then
+            assertThat(response).isNotNull();
+        }
+
+        @DisplayName("언어 코드가 존재하지 않을 경우 예외가 발생한다")
+        @Test
+        void notExistLanguage() {
+            // given
+            long id = 1L;
+            String notExistLang = "notExist";
+
+            // when & then
+            assertThatThrownBy(() -> placeService.findById(id, notExistLang))
+                .hasMessageContaining(INVALID_LANGUAGE.getMessage());
+        }
+
+        @DisplayName("Place 가 존재하지 않을 경우 예외가 발생한다")
+        @Test
+        void notExistPlace() {
+            // given
+            long notExistId = 0L;
+            String lang = "kor";
+
+            // mock
+            Language language = new Language(lang);
+            when(languageRepository.findByCode(lang)).thenReturn(Optional.of(language));
+
+            // when & then
+            assertThatThrownBy(() -> placeService.findById(notExistId, lang))
+                .hasMessage(NOT_EXIST_PLACE.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
[이전 PR](https://github.com/gongmo-girls/backend/pull/1) 에 이어 첫번째 API 를 구현하다보니,
팀 내부에서 결정해야 하는 것들이 많습니다 ㅎㅎ
간단하게 PR 에 정리해두었으니 의견 남겨주시기 바랍니다!

## 1. 프로젝트 계층 구조
- 현재 : controller, service, repository, domain
- 방법1 : (상위 도메인) - controller, service, …
- 방법2 : controller, service, … - (상위 도메인)
- 서비스가 확장됨에 따라 관련 클래스가 매우 많이 증가될 것으로 예상되어 폴더 구조를 세분화 필요성이 생김
- 상위 도메인 예시 : 사용자, 지도, 리뷰 등

## 2. domain 과 entity 저장 경로
- 현재 : domain 폴더 및 repository/entity 폴더에서 구분
    - domain : 엔티티 외의 모든 객체 (일반 도메인, enum, error code 등)
    - entity : 테이블이 생성되는 엔티티
- 방법1 : 모두 domain 폴더로 이동
- 방법2 : 모두 entity 폴더로 이동 (repository/entity 가 아닌 entity)
- 방법3 : 새로운 방법 추천해주세요^^

## 3. 다대다 연관관계 중간 테이블 관리
- 현재 : 중간 테이블 직접 생성 (@OneToMany 와 @ManyToOne 으로 연결)
    - 자동 생성 테이블이 존재하지 않아 모든 테이블을 코드에서 관리 가능
    - 중간 테이블에 별다른 컬럼이 없는 경우 이중으로 관리하여 번거로울 수 있음
- 방법1 : Hibernate 자동 생성 (@ManyToMany 로 생성)
    - 관리 필요 없는 테이블 감추기 가능

## 4. 타입 관리 위치 (Java enum vs 테이블)
- 현재 : 다른 테이블에서 참조하는 경우가 없는 경우 Java, 있으면 테이블
    - ImagePlaceType 처럼 참조하는 경우가 없으면 Enum 으로 생성
    - HashTag, Language 처럼 참조하는 경우 테이블 생성
 - 여러분의 의견이 궁금합니당

## 5. JPA Repository 테스트 범위
- 5-1. 미리 정의된 메서드 중 사용하는 메서드
- 5-2. 네이밍 규칙에 따라 생성한 메서드
- 5-3. JPQL 쿼리문 작성한 메서드
- 현재 : 실제 Repository 에서 선언한 메서드만 테스트 작성했습니다. (2+3)

## 6. test fixture 관리 방식
- 저는 매번 enum 으로 했었는데 다른 분들은 어떻게 관리했었는지 궁금해요